### PR TITLE
Improve rAF game loop with delta-time accumulator

### DIFF
--- a/assets/game-loop.js
+++ b/assets/game-loop.js
@@ -1,0 +1,29 @@
+"use strict";
+
+export function createGameLoop({ dropInterval = 1000, maxDt = 100 } = {}) {
+    let dropAccum = 0;
+    let lastTimestamp = -1;
+    let fastDropPending = false;
+
+    return {
+        reset() {
+            dropAccum = 0;
+            lastTimestamp = -1;
+            fastDropPending = false;
+        },
+        requestFastDrop() {
+            fastDropPending = true;
+        },
+        tick(timestamp) {
+            const dt = lastTimestamp < 0 ? 0 : Math.min(timestamp - lastTimestamp, maxDt);
+            lastTimestamp = timestamp;
+            dropAccum += dt;
+            if (fastDropPending || dropAccum >= dropInterval) {
+                fastDropPending = false;
+                dropAccum = 0;
+                return true;
+            }
+            return false;
+        }
+    };
+}

--- a/assets/game-loop.test.js
+++ b/assets/game-loop.test.js
@@ -1,0 +1,98 @@
+import {createGameLoop} from './game-loop.js';
+
+// Simulate N frames at ~16ms intervals starting from a given time
+function tickFrames(loop, startTime, count) {
+    let result = false;
+    for (let i = 1; i <= count; i++) {
+        result = loop.tick(startTime + i * 16);
+    }
+    return result;
+}
+
+describe('createGameLoop', () => {
+    let loop;
+
+    beforeEach(() => {
+        loop = createGameLoop();
+    });
+
+    test('does not trigger drop before 1000ms', () => {
+        loop.tick(0); // first frame, dt=0
+        // ~62 frames = 992ms, not enough
+        expect(tickFrames(loop, 0, 62)).toBe(false);
+    });
+
+    test('triggers drop after 1000ms of frames', () => {
+        loop.tick(0);
+        // ~63 frames = 1008ms, should trigger
+        expect(tickFrames(loop, 0, 63)).toBe(true);
+    });
+
+    test('resets accumulator after a drop', () => {
+        loop.tick(0);
+        // Accumulate to first drop
+        const dropTime = 63 * 16; // 1008ms
+        tickFrames(loop, 0, 63); // triggers drop
+
+        // After drop, accumulator resets — need another 1000ms
+        expect(tickFrames(loop, dropTime, 62)).toBe(false); // 992ms
+        expect(loop.tick(dropTime + 63 * 16)).toBe(true);   // 1008ms
+    });
+
+    test('fast drop triggers on the very next tick', () => {
+        loop.tick(0);
+        loop.tick(100); // 100ms accumulated (capped, but only 1 frame so 100ms)
+        loop.requestFastDrop();
+        expect(loop.tick(116)).toBe(true);
+    });
+
+    test('fast drop flag is cleared after use', () => {
+        loop.tick(0);
+        loop.requestFastDrop();
+        loop.tick(16); // consumes the fast drop
+        expect(loop.tick(32)).toBe(false); // back to normal timing
+    });
+
+    test('dt spike is capped at maxDt', () => {
+        loop.tick(0);
+        // 5-second gap — only maxDt (100ms) should accumulate
+        loop.tick(5000);
+        // Total accum is now 100ms. Need 900ms more → 57 frames (57*16=912)
+        expect(tickFrames(loop, 5000, 56)).toBe(false); // 896ms + 100ms = 996ms
+        expect(loop.tick(5000 + 57 * 16)).toBe(true);   // 912ms + 100ms = 1012ms
+    });
+
+    test('custom maxDt is respected', () => {
+        loop = createGameLoop({ maxDt: 200 });
+        loop.tick(0);
+        // 5-second gap — capped to 200ms
+        loop.tick(5000);
+        // accum = 200ms. Need 800ms more → 50 frames
+        expect(tickFrames(loop, 5000, 49)).toBe(false);
+        expect(loop.tick(5000 + 50 * 16)).toBe(true);
+    });
+
+    test('custom dropInterval is respected', () => {
+        loop = createGameLoop({ dropInterval: 500 });
+        loop.tick(0);
+        // 500ms / 16ms = 31.25 → need 32 frames (32*16=512)
+        expect(tickFrames(loop, 0, 31)).toBe(false); // 496ms
+        expect(loop.tick(32 * 16)).toBe(true);        // 512ms >= 500
+    });
+
+    test('reset clears all state', () => {
+        loop.tick(0);
+        tickFrames(loop, 0, 50); // accumulate ~800ms
+        loop.requestFastDrop();
+        loop.reset();
+        // After reset: first tick gives dt=0, no fast drop pending
+        expect(loop.tick(2000)).toBe(false);
+        // Then need 1000ms of normal frames
+        expect(tickFrames(loop, 2000, 62)).toBe(false);
+        expect(loop.tick(2000 + 63 * 16)).toBe(true);
+    });
+
+    test('first frame always yields dt=0', () => {
+        expect(loop.tick(99999)).toBe(false);
+    });
+});

--- a/assets/index.js
+++ b/assets/index.js
@@ -4,10 +4,10 @@ import gameArea from './table.js';
 import {score, setId, scoreBoardDiv, timeInput, scoreInput} from './scoreboard.js';
 import tetrisBlock from './tetris-block.js';
 import timer from './timer.js';
+import {createGameLoop} from './game-loop.js';
 
-let wait;
-let prevTime;
-let runID, waitID;
+let loopID;
+const loop = createGameLoop();
 let started = false;
 let curBlocks;
 let gameTimer;
@@ -334,7 +334,7 @@ const slowDrop = function() {
 };
 
 const fastDrop = function() {
-    wait = 0;
+    loop.requestFastDrop();
 };
 
 const moveRight = function() {
@@ -390,39 +390,26 @@ document.addEventListener("keydown", (e) => {
     }
 });
 
-const checkWait = function(timestamp) {
-    // if the fall is called right after the execution of the game (prevTime is falsy)
-    // i.e. executes if just after falling one row
-    if (!prevTime) {
-        prevTime = timestamp;
-    }
+const gameLoop = function(timestamp) {
+    if (!started) return;
 
-    let runtime = timestamp - prevTime;
-    if (runtime >= wait) {
-        slowDrop(); // fall a line if runtime of this round has exceeded the wait time (1 sec if slow, 0 if fast)
-        runID = requestAnimationFrame(run);
-    } else {
-        // continue waiting, and listening to events
-        waitID = requestAnimationFrame(checkWait);
-    }
-}
-
-const run = function() {
-    // after falling a line, reset prevTime and wait (in case it's changed by fast drop)
-    wait = 1000;
-    prevTime = null;
-    console.log("in run");
     timeDisplay.textContent = `${gameTimer.time}`;
     scoreDisplay.textContent = `Score: ${score}`;
-    if (curBlocks.endGame) {
-        gameover();
-        return;
+
+    if (loop.tick(timestamp)) {
+        slowDrop();
+
+        if (curBlocks.endGame) {
+            gameover();
+            return;
+        }
+        if (curBlocks.endSoon) {
+            scoreBoardDiv.style.willChange = "opacity";
+        }
     }
-    if (curBlocks.endSoon) {
-        scoreBoardDiv.style.willChange = "opacity";
-    }
-    waitID = requestAnimationFrame(checkWait);
-}
+
+    loopID = requestAnimationFrame(gameLoop);
+};
 
 // Start game handler (shared by ENTER key and START button)
 function startGame() {
@@ -440,7 +427,8 @@ function startGame() {
     box2.classList.remove("hidden");
     box3.classList.remove("hidden");
     gameTimer = new timer(Date.now());
-    run();
+    loop.reset();
+    loopID = requestAnimationFrame(gameLoop);
 }
 
 startBtn.addEventListener("click", startGame);
@@ -484,8 +472,7 @@ document.addEventListener("keydown", (e) => {
 })
 
 const gameover = function() {
-    cancelAnimationFrame(runID);
-    cancelAnimationFrame(waitID);
+    cancelAnimationFrame(loopID);
     enterPlayerName();
 }
 // temp game over


### PR DESCRIPTION
## Summary

- Replaces the two-phase `run()`/`checkWait()` busy-polling loop with a single `gameLoop(timestamp)` using a delta-time accumulator
- Extracts all timing logic into a new pure module `assets/game-loop.js` (`createGameLoop`) with no DOM dependencies
- Fast drop (ArrowDown) now sets a boolean flag instead of mutating the wait interval, making it frame-rate independent
- `gameover()` cancels a single rAF ID instead of two
- UI (score, timer) updates every frame instead of only after each drop
- dt spikes (e.g. tab-switch) are capped at 100ms to prevent multi-row drops in one tick

## Test plan

- [ ] `cd assets && npm test` — all 17 tests pass (10 new game-loop tests + 7 existing table tests)
- [ ] Start a game — pieces fall once per second as before
- [ ] Hold ArrowDown — fast drop works correctly
- [ ] Let pieces stack to game-over — scoreboard modal appears cleanly
- [ ] Press Backspace mid-game — game ends with no console errors